### PR TITLE
macOS ARM release workflow build & publish .dmg on tag

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -1,0 +1,31 @@
+name: Release macOS
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  build-macos:
+    runs-on: macos-14  # Apple Silicon M1
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build DMG
+        run: bun run tauri build -- --bundles dmg
+
+      - name: Upload to Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: src-tauri/target/release/bundle/dmg/*.dmg
+          fail_on_unmatched_files: true

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -6,9 +6,12 @@ on:
       - 'v*'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   build-macos:
-    runs-on: macos-14  # Apple Silicon M1
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## What this does

Adds a GitHub Actions workflow that automatically builds and publishes a `.dmg` installer whenever a version tag (`v*`) is pushed.

- Runs on `macos-14` (Apple Silicon M1 native runner)
- Builds with `bun run tauri build --bundles dmg`
- Uploads the `.dmg` as a GitHub Release asset
- Also triggerable manually via `workflow_dispatch`

## Why

Right now there are no distributed binaries — users have to build from source. This workflow makes it a one-click download for macOS users (Apple Silicon and Intel via Rosetta).

## Usage

Once merged, push a version tag to trigger a release build:

```bash
git tag v0.2.0
git push origin v0.2.0
```

The `.dmg` will appear as a release asset within ~20 minutes.