### PR TITLE
ci: trigger getdictus.com rebuild on release publish

### DIFF
--- a/.github/workflows/website-deploy-on-release.yml
+++ b/.github/workflows/website-deploy-on-release.yml
@@ -1,0 +1,21 @@
+name: "Trigger getdictus.com rebuild"
+
+# Fires when a GitHub Release is published (moved from draft to public).
+# This is the correct trigger — release.yml creates a DRAFT and Pierre
+# publishes manually via the GitHub UI. Only after the "Publish release"
+# click does latest.json become accessible at
+# https://github.com/getdictus/dictus-desktop/releases/latest/download/latest.json
+# and the release show up in the public API. Rebuilding the site any
+# earlier would serve stale release data to visitors.
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  trigger-rebuild:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger getdictus.com rebuild
+        if: success()
+        run: curl -fsSL -X POST "${{ secrets.VERCEL_WEBSITE_DEPLOY_HOOK }}"


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/website-deploy-on-release.yml` — a tiny workflow that POSTs to the `VERCEL_WEBSITE_DEPLOY_HOOK` secret whenever a GitHub Release is moved from draft to published.
- The website at getdictus.com needs to rebuild whenever a new Dictus Desktop release ships so download links and version strings stay fresh.

## Design note — why a new workflow instead of a step in `release.yml`

The original brief suggested adding a curl step "at the end of `release.yml`". That workflow creates a **draft** release and uploads assets to it — the actual "Publish release" click is manual in the GitHub UI.

A rebuild triggered from inside `release.yml` would fire on every draft-creation run, **before** Pierre has had a chance to verify the artifacts or click Publish. At that point `releases/latest/download/latest.json` still serves the previous version, so the Vercel rebuild would pull stale release metadata.

Using `on: release: { types: [published] }` fires the hook at exactly the right moment: after the draft flips to published, `latest.json` and the release API are live, and the rebuild serves correct data.

## Flags preserved from the brief

- `if: success()` — skip the POST if any earlier step fails
- `curl -f` — non-zero exit on Vercel 4xx/5xx responses (visible in Actions logs)
- `curl -sS` — silent except on error; the URL is never printed in logs

## Secret

`VERCEL_WEBSITE_DEPLOY_HOOK` is already configured on `getdictus/dictus-desktop` (added 2026-04-24 before this commit).

## Test plan

- [ ] Merge this PR
- [ ] Publish a test release OR wait for the next real release (v0.1.3)
- [ ] Verify the `Trigger getdictus.com rebuild` workflow fires with `success`
- [ ] Verify a new Vercel deployment appears on the getdictus-website project
- [ ] Verify getdictus.com shows the new version string once the Vercel build completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)