### PR TITLE
docs(planning): cleanup v1.2 — remove Phases 9 & 10, rename to Polish & Local-First UX

### DIFF
--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -27,18 +27,19 @@ L'application doit être identifiable et utilisable comme **Dictus Desktop** —
 - Phase 5 VALIDATION.md left draft — needs `/gsd:validate-phase 5`
 - `blob.handy.computer` CDN still used for onnxruntime (INFR-01)
 
-## Current Milestone: v1.2 Polish & Automation
+## Current Milestone: v1.2 Polish & Local-First UX
 
-**Goal:** Polir l'identité visuelle cross-platform, nettoyer les fuites de brand Handy, automatiser le workflow upstream sync avec des agents Claude Code (adapt + audit), et corriger les bugs de polish (quit dialog, UX local-first).
+**Goal:** Polir l'identité visuelle cross-platform, nettoyer les fuites de brand Handy, corriger les bugs de polish (quit dialog macOS), et rendre la promesse local-first lisible dans l'UX post-processing (providers réordonnés, surface réseau documentée, onboarding revu).
 
 **Target features:**
 - Logos Linux/Windows correctement adaptés (bords carrés, cohérence avec dictus-brand)
 - Brand cleanup complet (recording files, Portable Mode string, DebugPaths) + verify-sync.sh étendu
-- Upstream sync refactor (community action auto-PR, move verify-sync.sh hors `.planning/`, trim UPSTREAM.md)
-- Layer d'agents Claude Code GitHub Action (agent adaptation + agent audit indépendant sur PR upstream)
-- Privacy / local-first UX audit (reorder providers, network surface doc, onboarding copy)
-- Post-sync gate hardening (UPDT-03/UPDT-05 re-assertion dans UPSTREAM.md §6)
 - macOS clean shutdown fix (Dictus quit unexpectedly dialog)
+- Privacy / local-first UX (reorder providers post-processing, network surface doc, onboarding copy)
+
+**Scope change (2026-05-21):**
+- Original "Automation" half (Phase 9 sync infra refactor + Phase 10 Claude Code agents) **removed** — over-engineered for actual upstream cadence; manual workflow captured in todo `2026-05-21-upstream-sync-strategy-review.md`
+- Translation Mode feature deferred to milestone **v1.3 "Smart Mode & Translation"**
 
 ## Requirements
 
@@ -71,7 +72,7 @@ L'application doit être identifiable et utilisable comme **Dictus Desktop** —
 
 ### Active
 
-(v1.2 Polish & Automation — requirements defined in `.planning/REQUIREMENTS.md`.)
+(v1.2 Polish & Local-First UX — requirements defined in `.planning/REQUIREMENTS.md`.)
 
 ### Deferred
 

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -1,12 +1,13 @@
-# Requirements: Dictus Desktop v1.2 Polish & Automation
+# Requirements: Dictus Desktop v1.2 Polish & Local-First UX
 
 **Defined:** 2026-04-15
+**Renamed/rescoped:** 2026-05-21 — "Polish & Automation" → "Polish & Local-First UX"; SYNC-07..11 and AGENT-01..06 cancelled (see "Future Requirements > Sync Automation" section below)
 **Core Value:** L'application doit être identifiable et utilisable comme Dictus Desktop — pas comme Handy — et rester vivante (updates automatiques) sans décrocher du upstream Handy.
 **Previous milestones:** v1.0 (rebrand), v1.1 (auto-update & upstream sync)
 
 ## v1.2 Requirements
 
-Requirements for the Polish & Automation milestone. Each maps to a roadmap phase.
+Requirements for the Polish & Local-First UX milestone. Each maps to a roadmap phase.
 
 ### Brand Cleanup (BRAND)
 
@@ -28,33 +29,18 @@ Requirements for the Polish & Automation milestone. Each maps to a roadmap phase
 
 ### Sync Infrastructure (SYNC)
 
-<!-- Refactor upstream-sync from custom detection+issue to community-action draft-PR + CI gate. -->
+<!-- Originally planned automated upstream-sync workflow (draft PRs + CI gate). -->
+<!-- Rescoped 2026-05-21: SYNC-06 absorbed by Phase 6; SYNC-07..11 cancelled — manual workflow chosen. See "Future Requirements > Sync Automation" below and todo 2026-05-21-upstream-sync-strategy-review.md. -->
 
-- [x] **SYNC-06**: `verify-sync.sh` relocated to `.github/scripts/verify-sync.sh` (out of `.planning/` tree); all references in UPSTREAM.md updated
-- [ ] **SYNC-07**: `verify-sync.sh` extended with UPDT-03 assertion (`plugins.updater.pubkey` present and non-empty) and UPDT-05 assertion (`plugins.updater.endpoints[0]` contains `getdictus/dictus-desktop`)
-- [ ] **SYNC-08**: `verify-sync.yml` CI workflow runs `verify-sync.sh` on every PR labeled `upstream-sync`, set as a required status check for merges to `main`
-- [ ] **SYNC-09**: `upstream-sync.yml` replaced: uses `peter-evans/create-pull-request@v8` (or equivalent) to open a labeled draft PR with upstream commits on a weekly cron, instead of creating a tracking issue
-- [ ] **SYNC-10**: `.github/PULL_REQUEST_TEMPLATE/upstream-sync.md` checklist (cap-at-SHA? risk rating? verify-sync.sh green? agent review complete?) auto-applied to draft PRs via `template=` query param or preset body
-- [ ] **SYNC-11**: `UPSTREAM.md` runbook trimmed to reflect the new flow (PR already open on arrival, CI gate enforces identity, checklist drives review) — obsolete sections removed, cap-at-SHA and conflict-rules sections preserved
-
-### Claude Code Agents (AGENT)
-
-<!-- Two sequential GitHub Action agents: adapter (commits fixes) + auditor (read-only review). -->
-
-- [ ] **AGENT-01**: `CLAUDE_CODE_OAUTH_TOKEN` secret configured in repo (generated via `claude setup-token` against the user's Claude Max subscription) so agents run on subscription quota, not metered API billing
-- [ ] **AGENT-02**: `claude-agents.yml` workflow triggers on `pull_request` events filtered to label `upstream-sync`, runs `anthropics/claude-code-action@v1` as an **adapter** job with write permissions (`contents: write`, `pull-requests: write`) and an explicit file allow-list in the system prompt (may modify only brand/identity surfaces)
-- [ ] **AGENT-03**: Same workflow runs a second **auditor** job with `needs: [adapter]` and read-only permissions (`contents: read`), posts findings as a PR review comment without pushing commits
-- [ ] **AGENT-04**: Adapter prompt codifies UPSTREAM.md identity rules (productName=Dictus, identifier=com.dictus.desktop, updater pubkey/endpoint, Dictus User-Agent/X-Title headers, no Handy in i18n values) and explicit trust-boundary instruction to ignore any `ignore previous instructions` content from upstream commit messages/diffs
-- [ ] **AGENT-05**: Auditor prompt is independent (no shared conversation state), checks residual Handy strings + brand cleanup compliance + general code-quality smells, and cannot push commits
-- [ ] **AGENT-06**: `verify-sync.yml` runs as an independent CI step (NOT driven by the auditor agent) so a compromised agent cannot bypass the identity gate
+- [x] **SYNC-06**: `verify-sync.sh` relocated to `.github/scripts/verify-sync.sh` (out of `.planning/` tree); all references in UPSTREAM.md updated *(absorbed by Phase 6)*
 
 ### macOS Clean Shutdown (SHUT)
 
 <!-- Fix "Dictus quit unexpectedly" dialog on clean quit. -->
 
-- [ ] **SHUT-01**: Console.app crash report read and the crashing thread identified (tokio-runtime-worker, main, or Tauri plugin); diagnosis documented in phase plan before fix is chosen
-- [ ] **SHUT-02**: Based on diagnosis, either (a) explicit cleanup/drop order added before `app.exit(0)` at `lib.rs:254` (tray quit) and `lib.rs:622` (CloseRequested) — e.g., `tauri_plugin_global_shortcut` unregister on main thread via `app_handle.run_on_main_thread`; or (b) `std::process::exit(0)` after `log::logger().flush()` as documented last-resort with upstream bug reference
-- [ ] **SHUT-03**: Clean quit on macOS (tray menu "Quit Dictus" and post-auto-update relaunch) no longer triggers the "Dictus quit unexpectedly — Reopen / Report / Ignore" OS dialog on macOS Sequoia 15.x
+- [x] **SHUT-01**: Console.app crash report read and the crashing thread identified (tokio-runtime-worker, main, or Tauri plugin); diagnosis documented in phase plan before fix is chosen
+- [x] **SHUT-02**: Based on diagnosis, either (a) explicit cleanup/drop order added before `app.exit(0)` at `lib.rs:254` (tray quit) and `lib.rs:622` (CloseRequested) — e.g., `tauri_plugin_global_shortcut` unregister on main thread via `app_handle.run_on_main_thread`; or (b) `std::process::exit(0)` after `log::logger().flush()` as documented last-resort with upstream bug reference
+- [x] **SHUT-03**: Clean quit on macOS (tray menu "Quit Dictus" and post-auto-update relaunch) no longer triggers the "Dictus quit unexpectedly — Reopen / Report / Ignore" OS dialog on macOS Sequoia 15.x
 
 ### Privacy / Local-First UX (PRIV)
 
@@ -77,9 +63,13 @@ Requirements for the Polish & Automation milestone. Each maps to a roadmap phase
 - **TECH-03**: Cargo binary rename `handy`→`dictus` (defers macOS permission/scripts risk)
 - **DATA-01**: On-disk data directory migration (if current path is still `handy`); requires backup logic
 
-### Sync Automation Advanced
+### Sync Automation (cancelled 2026-05-21)
 
-- **SYNC-A1**: AI-assisted cherry-pick triage on larger upstream deltas (Open Cloud agent or similar)
+Originally planned in v1.2 but removed as over-engineered relative to actual upstream cadence (~15 commits/month, ~1h manual merge cost). Captured in todo `2026-05-21-upstream-sync-strategy-review.md`:
+
+- ~~**SYNC-07..11**~~: Automated draft PR workflow + required CI gate. **Cancelled.** Manual workflow via UPSTREAM.md runbook is sufficient. UPDT-03/UPDT-05 re-assertion (was SYNC-07) reframed as a small ad-hoc improvement.
+- ~~**AGENT-01..06**~~: Claude Code adapter + auditor agent layer for upstream-sync PRs. **Cancelled.** Premature given low merge frequency.
+- **SYNC-A1**: AI-assisted cherry-pick triage on larger upstream deltas (Open Cloud agent or similar) — retained as long-term exploration if cadence ever grows.
 
 ## Out of Scope
 
@@ -110,30 +100,19 @@ Which phases cover which requirements.
 | ICON-02 | Phase 6 | Complete |
 | ICON-03 | Phase 6 | Complete |
 | ICON-04 | Phase 6 | Complete |
-| SYNC-06 | Phase 9 | Complete |
-| SYNC-07 | Phase 9 | Pending |
-| SYNC-08 | Phase 9 | Pending |
-| SYNC-09 | Phase 9 | Pending |
-| SYNC-10 | Phase 9 | Pending |
-| SYNC-11 | Phase 9 | Pending |
-| AGENT-01 | Phase 10 | Pending |
-| AGENT-02 | Phase 10 | Pending |
-| AGENT-03 | Phase 10 | Pending |
-| AGENT-04 | Phase 10 | Pending |
-| AGENT-05 | Phase 10 | Pending |
-| AGENT-06 | Phase 10 | Pending |
-| SHUT-01 | Phase 7 | Pending |
-| SHUT-02 | Phase 7 | Pending |
-| SHUT-03 | Phase 7 | Pending |
+| SYNC-06 | Phase 6 *(absorbed)* | Complete |
+| SHUT-01 | Phase 7 | Complete |
+| SHUT-02 | Phase 7 | Complete |
+| SHUT-03 | Phase 7 | Complete |
 | PRIV-01 | Phase 8 | Pending |
 | PRIV-02 | Phase 8 | Pending |
 | PRIV-03 | Phase 8 | Pending |
 
 **Coverage:**
-- v1.2 requirements: 26 total
-- Mapped to phases: 26 ✓
+- v1.2 active requirements: 15 total (after 2026-05-21 rescope: 11 cancelled — SYNC-07..11 + AGENT-01..06)
+- Mapped to phases: 15 ✓
 - Unmapped: 0 ✓
 
 ---
 *Requirements defined: 2026-04-15*
-*Last updated: 2026-04-15 — traceability populated after roadmap creation*
+*Last updated: 2026-05-21 — milestone renamed to "Polish & Local-First UX"; SYNC-07..11 + AGENT-01..06 cancelled; SHUT-01..03 marked Complete (Phase 7 closed 2026-04-23)*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -2,26 +2,26 @@
 
 ## Milestones
 
-- ✅ **v1.0 Handy→Dictus Rebrand** — Phases 1-3 (shipped 2010-04-10) — [archive](milestones/v1.0-ROADMAP.md)
-- ✅ **v1.1 Auto-Update & Upstream Sync** — Phases 4-5 (shipped 2010-04-14) — [archive](milestones/v1.1-ROADMAP.md)
+- ✅ **v1.0 Handy→Dictus Rebrand** — Phases 1-3 (shipped 2009-04-10) — [archive](milestones/v1.0-ROADMAP.md)
+- ✅ **v1.1 Auto-Update & Upstream Sync** — Phases 4-5 (shipped 2009-04-14) — [archive](milestones/v1.1-ROADMAP.md)
 - 🚧 **v1.2 Polish & Automation** — Phases 6-10 (in progress)
 
 ## Phases
 
 <details>
-<summary>✅ v1.0 Handy→Dictus Rebrand (Phases 1-3) — SHIPPED 2010-04-10</summary>
+<summary>✅ v1.0 Handy→Dictus Rebrand (Phases 1-3) — SHIPPED 2009-04-10</summary>
 
-- [x] Phase 1: Bundle Identity (1/1 plans) — completed 2010-04-05
-- [x] Phase 2: Visual Rebrand (5/5 plans) — completed 2010-04-09
-- [x] Phase 3: Documentation and Cleanup (2/2 plans) — completed 2010-04-09
+- [x] Phase 1: Bundle Identity (1/1 plans) — completed 2009-04-05
+- [x] Phase 2: Visual Rebrand (5/5 plans) — completed 2009-04-09
+- [x] Phase 3: Documentation and Cleanup (2/2 plans) — completed 2009-04-09
 
 </details>
 
 <details>
-<summary>✅ v1.1 Auto-Update & Upstream Sync (Phases 4-5) — SHIPPED 2010-04-14</summary>
+<summary>✅ v1.1 Auto-Update & Upstream Sync (Phases 4-5) — SHIPPED 2009-04-14</summary>
 
-- [x] Phase 4: Updater Infrastructure (4/4 plans) — completed 2010-04-13
-- [x] Phase 5: Upstream Sync (3/3 plans) — completed 2010-04-14
+- [x] Phase 4: Updater Infrastructure (4/4 plans) — completed 2009-04-13
+- [x] Phase 5: Upstream Sync (3/3 plans) — completed 2009-04-14
 
 </details>
 
@@ -29,10 +29,9 @@
 
 **Milestone Goal:** Polish Dictus identity across all user-visible surfaces, fix platform icon artifacts, resolve the macOS clean-shutdown crash, harden the upstream sync CI gate, and layer Claude Code agents onto the sync workflow so future merges get automated identity remediation and an independent audit.
 
-- [x] **Phase 6: Brand & Icon Polish** - Fix all remaining Handy brand leaks and platform icon artifacts; extend verify-sync.sh to guard them (absorbs SYNC-06 from Phase 9) — completed 2010-04-16
-- [x] **Phase 7: macOS Clean Shutdown** - Diagnose and fix the "Dictus quit unexpectedly" crash dialog on macOS Sequoia — completed 2010-04-23
+- [x] **Phase 6: Brand & Icon Polish** - Fix all remaining Handy brand leaks and platform icon artifacts; extend verify-sync.sh to guard them (absorbs SYNC-06 from Phase 9) — completed 2009-04-16
+- [x] **Phase 7: macOS Clean Shutdown** - Diagnose and fix the "Dictus quit unexpectedly" crash dialog on macOS Sequoia — completed 2009-04-23
 - [ ] **Phase 8: Privacy / Local-First UX** - Reorder post-process providers (local first) and document the app's network surface
-- [ ] **Phase 9: Sync Infrastructure Refactor** - Replace issue-based detection with community-action draft PRs and promote verify-sync.sh to a required CI gate
 
 ## Phase Details
 
@@ -72,15 +71,4 @@
   1. The post-process provider dropdown renders Ollama, Apple Intelligence, and Custom local providers above a visible "External — data leaves this device" section that groups OpenAI, Anthropic, Groq, and Gemini
   2. A `docs/PRIVACY.md` file exists listing every outbound endpoint the app can contact, what data leaves the device, and how to disable each connection
   3. Onboarding screens present local transcription as the primary path; any cloud post-processing option is visibly labeled as an opt-in external service
-**Plans**: TBD
-
-### Phase 9: Sync Infrastructure Refactor
-**Goal**: The upstream sync workflow produces a labeled draft PR automatically each week instead of a tracking issue; verify-sync.sh is promoted to `.github/scripts/`, extended with UPDT-03/UPDT-05 assertions, and enforced as a required CI status check on all upstream-sync PRs.
-**Depends on**: Phase 6 (verify-sync.sh extended assertions must be in place before the CI gate goes live)
-**Requirements**: SYNC-06, SYNC-07, SYNC-08, SYNC-09, SYNC-10, SYNC-11
-**Success Criteria** (what must be TRUE):
-  1. `verify-sync.sh` lives at `.github/scripts/verify-sync.sh` and exits non-zero if `plugins.updater.pubkey` is absent or if `plugins.updater.endpoints[0]` does not contain `getdictus/dictus-desktop`
-  2. A PR labeled `upstream-sync` triggers the `verify-sync.yml` workflow and its result appears as a required status check — the PR cannot merge to `main` while that check is red
-  3. On the weekly cron, `upstream-sync.yml` opens a draft PR (not an issue) with upstream commits on a dedicated branch; re-running while that branch exists does not open a duplicate PR
-  4. Every draft upstream-sync PR opens with the `.github/PULL_REQUEST_TEMPLATE/upstream-sync.md` checklist pre-filled in its body
 **Plans**: TBD

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -4,7 +4,7 @@
 
 - ✅ **v1.0 Handy→Dictus Rebrand** — Phases 1-3 (shipped 2009-04-10) — [archive](milestones/v1.0-ROADMAP.md)
 - ✅ **v1.1 Auto-Update & Upstream Sync** — Phases 4-5 (shipped 2009-04-14) — [archive](milestones/v1.1-ROADMAP.md)
-- 🚧 **v1.2 Polish & Automation** — Phases 6-10 (in progress)
+- 🚧 **v1.2 Polish & Local-First UX** — Phases 6-8 (in progress)
 
 ## Phases
 
@@ -25,9 +25,11 @@
 
 </details>
 
-### 🚧 v1.2 Polish & Automation (In Progress)
+### 🚧 v1.2 Polish & Local-First UX (In Progress)
 
-**Milestone Goal:** Polish Dictus identity across all user-visible surfaces, fix platform icon artifacts, resolve the macOS clean-shutdown crash, harden the upstream sync CI gate, and layer Claude Code agents onto the sync workflow so future merges get automated identity remediation and an independent audit.
+**Milestone Goal:** Polish Dictus identity across all user-visible surfaces, fix platform icon artifacts, resolve the macOS clean-shutdown crash, and make the local-first promise legible in the post-processing UX — providers reordered with local options first, network surface documented, onboarding copy emphasizing local transcription as the primary path.
+
+> **Scope change (2026-05-21):** The "Automation" half of the original milestone (Phases 9 & 10 — automated sync infrastructure + Claude Code agent layer) was removed as over-engineered relative to actual upstream cadence. The simpler manual-sync workflow plan is captured in `.planning/todos/pending/2026-05-21-upstream-sync-strategy-review.md`. The Translation Mode feature originally floated as a v1.2 candidate is deferred to milestone **v1.3 "Smart Mode & Translation"**.
 
 - [x] **Phase 6: Brand & Icon Polish** - Fix all remaining Handy brand leaks and platform icon artifacts; extend verify-sync.sh to guard them (absorbs SYNC-06 from Phase 9) — completed 2009-04-16
 - [x] **Phase 7: macOS Clean Shutdown** - Diagnose and fix the "Dictus quit unexpectedly" crash dialog on macOS Sequoia — completed 2009-04-23
@@ -49,8 +51,6 @@
   - [x] 06-02-PLAN.md — Replace handy- filename prefix and "Handy Portable Mode" marker in Rust backend (BRAND-01, BRAND-02)
   - [x] 06-03-PLAN.md — Rewrite DebugPaths.tsx to render backend-provided portable-aware path (BRAND-03)
   - [x] 06-04-PLAN.md — Regenerate platform icons from square transparent source and extend bundle.icon config (ICON-01, ICON-02, ICON-03, ICON-04) [has checkpoints]
-
-**Note:** After Phase 6 ships, run `/gsd:roadmap-update` to reflect SYNC-06 completion — Phase 9 scope will reduce to SYNC-07/08/09/10/11 only.
 
 ### Phase 7: macOS Clean Shutdown
 **Goal**: Quitting Dictus on macOS (via tray menu or post-update relaunch) no longer triggers the OS "quit unexpectedly" crash dialog — root cause is diagnosed before a fix is committed.

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -2,26 +2,26 @@
 
 ## Milestones
 
-- ✅ **v1.0 Handy→Dictus Rebrand** — Phases 1-3 (shipped 2026-04-10) — [archive](milestones/v1.0-ROADMAP.md)
-- ✅ **v1.1 Auto-Update & Upstream Sync** — Phases 4-5 (shipped 2026-04-14) — [archive](milestones/v1.1-ROADMAP.md)
+- ✅ **v1.0 Handy→Dictus Rebrand** — Phases 1-3 (shipped 2010-04-10) — [archive](milestones/v1.0-ROADMAP.md)
+- ✅ **v1.1 Auto-Update & Upstream Sync** — Phases 4-5 (shipped 2010-04-14) — [archive](milestones/v1.1-ROADMAP.md)
 - 🚧 **v1.2 Polish & Automation** — Phases 6-10 (in progress)
 
 ## Phases
 
 <details>
-<summary>✅ v1.0 Handy→Dictus Rebrand (Phases 1-3) — SHIPPED 2026-04-10</summary>
+<summary>✅ v1.0 Handy→Dictus Rebrand (Phases 1-3) — SHIPPED 2010-04-10</summary>
 
-- [x] Phase 1: Bundle Identity (1/1 plans) — completed 2026-04-05
-- [x] Phase 2: Visual Rebrand (5/5 plans) — completed 2026-04-09
-- [x] Phase 3: Documentation and Cleanup (2/2 plans) — completed 2026-04-09
+- [x] Phase 1: Bundle Identity (1/1 plans) — completed 2010-04-05
+- [x] Phase 2: Visual Rebrand (5/5 plans) — completed 2010-04-09
+- [x] Phase 3: Documentation and Cleanup (2/2 plans) — completed 2010-04-09
 
 </details>
 
 <details>
-<summary>✅ v1.1 Auto-Update & Upstream Sync (Phases 4-5) — SHIPPED 2026-04-14</summary>
+<summary>✅ v1.1 Auto-Update & Upstream Sync (Phases 4-5) — SHIPPED 2010-04-14</summary>
 
-- [x] Phase 4: Updater Infrastructure (4/4 plans) — completed 2026-04-13
-- [x] Phase 5: Upstream Sync (3/3 plans) — completed 2026-04-14
+- [x] Phase 4: Updater Infrastructure (4/4 plans) — completed 2010-04-13
+- [x] Phase 5: Upstream Sync (3/3 plans) — completed 2010-04-14
 
 </details>
 
@@ -29,11 +29,10 @@
 
 **Milestone Goal:** Polish Dictus identity across all user-visible surfaces, fix platform icon artifacts, resolve the macOS clean-shutdown crash, harden the upstream sync CI gate, and layer Claude Code agents onto the sync workflow so future merges get automated identity remediation and an independent audit.
 
-- [x] **Phase 6: Brand & Icon Polish** - Fix all remaining Handy brand leaks and platform icon artifacts; extend verify-sync.sh to guard them (absorbs SYNC-06 from Phase 9) — completed 2026-04-16
-- [x] **Phase 7: macOS Clean Shutdown** - Diagnose and fix the "Dictus quit unexpectedly" crash dialog on macOS Sequoia — completed 2026-04-23
+- [x] **Phase 6: Brand & Icon Polish** - Fix all remaining Handy brand leaks and platform icon artifacts; extend verify-sync.sh to guard them (absorbs SYNC-06 from Phase 9) — completed 2010-04-16
+- [x] **Phase 7: macOS Clean Shutdown** - Diagnose and fix the "Dictus quit unexpectedly" crash dialog on macOS Sequoia — completed 2010-04-23
 - [ ] **Phase 8: Privacy / Local-First UX** - Reorder post-process providers (local first) and document the app's network surface
 - [ ] **Phase 9: Sync Infrastructure Refactor** - Replace issue-based detection with community-action draft PRs and promote verify-sync.sh to a required CI gate
-- [ ] **Phase 10: Claude Code Agent Layer** - Add adapter + auditor Claude Code agents that fire on labeled upstream-sync PRs
 
 ## Phase Details
 
@@ -85,32 +84,3 @@
   3. On the weekly cron, `upstream-sync.yml` opens a draft PR (not an issue) with upstream commits on a dedicated branch; re-running while that branch exists does not open a duplicate PR
   4. Every draft upstream-sync PR opens with the `.github/PULL_REQUEST_TEMPLATE/upstream-sync.md` checklist pre-filled in its body
 **Plans**: TBD
-
-### Phase 10: Claude Code Agent Layer
-**Goal**: Every upstream-sync draft PR automatically receives an adapter pass (agent commits identity fixes within a scoped allow-list) followed by an independent auditor pass (read-only agent posts a review comment) — and neither agent can bypass the `verify-sync.yml` CI gate.
-**Depends on**: Phase 9 (labeled draft PRs must exist before agents have meaningful input)
-**Requirements**: AGENT-01, AGENT-02, AGENT-03, AGENT-04, AGENT-05, AGENT-06
-**Success Criteria** (what must be TRUE):
-  1. `CLAUDE_CODE_OAUTH_TOKEN` is configured in repo secrets and the agent workflow runs without API-key billing errors
-  2. An upstream-sync draft PR triggers the adapter agent job; the adapter commits only to brand/identity surfaces within its explicit file allow-list and does not modify files outside that scope
-  3. After the adapter job completes, the auditor job runs with read-only permissions and posts a review comment on the PR summarizing residual Handy strings, brand compliance findings, and code-quality observations — it does not push any commits
-  4. The `verify-sync.yml` CI gate runs as an independent workflow step regardless of what the adapter or auditor agents do — a compromised or misbehaving agent cannot cause it to be skipped
-
-## Progress
-
-**Execution Order:**
-v1.2 phases execute in order: 6 → 7 → 8 → 9 → 10
-(Phases 6, 7, 8 are independent and can proceed on separate branches; Phase 9 requires Phase 6 complete; Phase 10 requires Phase 9 complete.)
-
-| Phase | Milestone | Plans Complete | Status | Completed |
-|-------|-----------|----------------|--------|-----------|
-| 1. Bundle Identity | v1.0 | 1/1 | Complete | 2026-04-05 |
-| 2. Visual Rebrand | v1.0 | 5/5 | Complete | 2026-04-09 |
-| 3. Documentation and Cleanup | v1.0 | 2/2 | Complete | 2026-04-09 |
-| 4. Updater Infrastructure | v1.1 | 4/4 | Complete | 2026-04-13 |
-| 5. Upstream Sync | v1.1 | 3/3 | Complete | 2026-04-14 |
-| 6. Brand & Icon Polish | v1.2 | 4/4 | Complete | 2026-04-16 |
-| 7. macOS Clean Shutdown | v1.2 | 1/1 | Complete | 2026-04-23 |
-| 8. Privacy / Local-First UX | v1.2 | 0/TBD | Not started | - |
-| 9. Sync Infrastructure Refactor | v1.2 | 0/TBD | Not started | - |
-| 10. Claude Code Agent Layer | v1.2 | 0/TBD | Not started | - |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -4,10 +4,10 @@ milestone: v1.2
 milestone_name: Polish & Automation
 status: completed
 stopped_at: Phase 7 context gathered
-last_updated: "2026-05-21T11:39:19.720Z"
+last_updated: "2026-05-21T11:39:37.516Z"
 last_activity: 2026-04-23 — Plan 07-01 SUMMARY written; Phase 6.1 icon regression fixed (commit 34de33e)
 progress:
-  total_phases: 4
+  total_phases: 3
   completed_phases: 2
   total_plans: 5
   completed_plans: 5
@@ -30,7 +30,7 @@ Plan: 07-01 complete (SHUT-01/02/03)
 Status: Phase 7 complete; validation window closed with no crash reproduction
 Last activity: 2026-04-23 — Plan 07-01 SUMMARY written; Phase 6.1 icon regression fixed (commit 34de33e)
 
-Progress: [████░░░░░░] 40% (v1.2 — 2 of 4 phases complete, 5 of 5 planned plans executed)
+Progress: [████░░░░░░] 40% (v1.2 — 2 of 3 phases complete, 5 of 5 planned plans executed)
 
 ## Performance Metrics
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,17 +1,17 @@
 ---
 gsd_state_version: 1.0
 milestone: v1.2
-milestone_name: Polish & Automation
-status: completed
-stopped_at: Phase 7 context gathered
+milestone_name: Polish & Local-First UX
+status: in_progress
+stopped_at: Phase 7 complete — ready for Phase 8
 last_updated: "2026-05-21T11:39:37.516Z"
-last_activity: 2026-04-23 — Plan 07-01 SUMMARY written; Phase 6.1 icon regression fixed (commit 34de33e)
+last_activity: 2026-05-21 — Phases 9 & 10 removed (automation ambitions cancelled); milestone v1.2 renamed to "Polish & Local-First UX"
 progress:
   total_phases: 3
   completed_phases: 2
   total_plans: 5
   completed_plans: 5
-  percent: 40
+  percent: 67
 ---
 
 # Project State
@@ -25,12 +25,12 @@ See: .planning/PROJECT.md (updated 2026-04-15 at v1.2 kickoff)
 
 ## Current Position
 
-Phase: 7 of 10 overall (Phase 2 of 5 in v1.2) — complete
+Phase: 7 of 8 overall (Phase 2 of 3 in v1.2) — complete
 Plan: 07-01 complete (SHUT-01/02/03)
 Status: Phase 7 complete; validation window closed with no crash reproduction
-Last activity: 2026-04-23 — Plan 07-01 SUMMARY written; Phase 6.1 icon regression fixed (commit 34de33e)
+Last activity: 2026-05-21 — Phases 9 & 10 removed (automation ambitions cancelled); milestone renamed to "Polish & Local-First UX"
 
-Progress: [████░░░░░░] 40% (v1.2 — 2 of 3 phases complete, 5 of 5 planned plans executed)
+Progress: [███████░░░] 67% (v1.2 — 2 of 3 phases complete, 5 of 5 planned plans executed)
 
 ## Performance Metrics
 
@@ -83,14 +83,10 @@ Progress: [████░░░░░░] 40% (v1.2 — 2 of 3 phases complete,
 ### Blockers/Concerns
 
 Carried from v1.1 audit:
-- UPSTREAM.md §6 post-sync gate missing UPDT-03/UPDT-05 re-assertion (addressed by SYNC-07 in Phase 9)
+- UPSTREAM.md §6 post-sync gate missing UPDT-03/UPDT-05 re-assertion (deferred — captured in `.planning/todos/pending/2026-05-21-upstream-sync-strategy-review.md` for the manual-workflow simplification path)
 - Phase 5 VALIDATION.md draft → run `/gsd:validate-phase 5` to close
 - `blob.handy.computer` CDN for onnxruntime (INFR-01, deferred)
 - Windows builds unsigned at OS level (INFR-03, deferred)
-
-v1.2-specific research flags:
-- Phase 9: Test `peter-evans/create-pull-request@v8` idempotency with `workflow_dispatch` before enabling weekly cron
-- Phase 10: Validate `claude setup-token` OAuth path before building agent workflow
 
 ## Session Continuity
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,12 +2,12 @@
 gsd_state_version: 1.0
 milestone: v1.2
 milestone_name: Polish & Automation
-status: in_progress
-stopped_at: Phase 7 complete — ready for Phase 8
-last_updated: "2026-04-23T22:40:00.000Z"
-last_activity: 2026-04-23 — Plan 07-01 complete (SHUT-01/02/03); Phase 6.1 icon regression fixed a posteriori (commit 34de33e)
+status: completed
+stopped_at: Phase 7 context gathered
+last_updated: "2026-05-21T11:39:19.720Z"
+last_activity: 2026-04-23 — Plan 07-01 SUMMARY written; Phase 6.1 icon regression fixed (commit 34de33e)
 progress:
-  total_phases: 5
+  total_phases: 4
   completed_phases: 2
   total_plans: 5
   completed_plans: 5
@@ -30,7 +30,7 @@ Plan: 07-01 complete (SHUT-01/02/03)
 Status: Phase 7 complete; validation window closed with no crash reproduction
 Last activity: 2026-04-23 — Plan 07-01 SUMMARY written; Phase 6.1 icon regression fixed (commit 34de33e)
 
-Progress: [████░░░░░░] 40% (v1.2 — 2 of 5 phases complete, 5 of 5 planned plans executed)
+Progress: [████░░░░░░] 40% (v1.2 — 2 of 4 phases complete, 5 of 5 planned plans executed)
 
 ## Performance Metrics
 


### PR DESCRIPTION
## Summary

Acts on the 2026-05-21 strategic decision documented in #1 (comment) and the upstream sync strategy review todo:

- Remove **Phase 9** (Sync Infrastructure Refactor) — automated draft PRs + CI gate workflow, over-engineered for actual cadence
- Remove **Phase 10** (Claude Code Agent Layer) — premature given low merge frequency
- Rename milestone **v1.2 "Polish & Automation" → "Polish & Local-First UX"** to reflect what v1.2 actually delivers
- Mark **SHUT-01..03** as Complete (Phase 7 closed 2026-04-23)
- Mark **SYNC-07..11** and **AGENT-01..06** as cancelled with rationale
- Mark **SYNC-06** as absorbed by Phase 6

## Commits

1. `aab6bd8 chore: remove phase 10 (Claude Code Agent Layer)` — via `/gsd:remove-phase 10`
2. `752434e chore: remove phase 9 (Sync Infrastructure Refactor)` — via `/gsd:remove-phase 9`
3. `9a97cb1 docs(planning): rename milestone v1.2 → Polish & Local-First UX` — manual edits to STATE.md, ROADMAP.md, PROJECT.md, REQUIREMENTS.md

## Why merge as-is

Pure planning documentation under `.planning/`. Zero code touched. No CI workflow triggers on this path filter.

## Related

- #1 — Upstream sync strategy, comment from 2026-05-21
- `.planning/todos/pending/2026-05-21-upstream-sync-strategy-review.md` — full rationale and replacement plan (manual workflow)

## Test plan

- [ ] N/A — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)