### PR TITLE
fix(overlay): recording pill intermittently fails to appear / flashes <1s on macOS (#31)

### DIFF
--- a/src-tauri/src/overlay.rs
+++ b/src-tauri/src/overlay.rs
@@ -31,6 +31,20 @@ tauri_panel! {
     })
 }
 
+/// Monotonic counter bumped on every overlay show (`show_overlay_state`). A
+/// delayed `hide()` captures the generation current when it was scheduled and
+/// only fires if that generation is still the latest; if a newer show has
+/// occurred since (e.g. the next dictation's recording pill), the stale hide is
+/// skipped so it can't hide the panel mid-recording (issue #31).
+static OVERLAY_GENERATION: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// Returns true if a delayed overlay hide scheduled at `scheduled_generation`
+/// should still execute — i.e. no newer overlay show has bumped the generation
+/// since. Pure function so the issue #31 guard rule can be unit-tested.
+fn delayed_hide_is_current(scheduled_generation: u64, current_generation: u64) -> bool {
+    scheduled_generation == current_generation
+}
+
 const OVERLAY_WIDTH: f64 = 400.0;
 const OVERLAY_HEIGHT: f64 = 84.0;
 
@@ -329,6 +343,10 @@ fn show_overlay_state(app_handle: &AppHandle, state: &str) {
         return;
     }
 
+    // Bump the overlay generation so any delayed hide() scheduled by a previous
+    // dictation knows it has been superseded and must not fire (issue #31).
+    OVERLAY_GENERATION.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+
     update_overlay_position(app_handle);
 
     if let Some(overlay_window) = app_handle.get_webview_window("recording_overlay") {
@@ -385,6 +403,9 @@ pub fn hide_recording_overlay(app_handle: &AppHandle) {
     // Always hide the overlay regardless of settings - if setting was changed while recording,
     // we still want to hide it properly
     if let Some(overlay_window) = app_handle.get_webview_window("recording_overlay") {
+        // Capture the overlay generation at schedule time so the delayed hide()
+        // below can tell whether a newer show has superseded it (issue #31).
+        let scheduled_generation = OVERLAY_GENERATION.load(std::sync::atomic::Ordering::SeqCst);
         // Emit event to trigger fade-out animation
         let _ = overlay_window.emit("hide-overlay", ());
         // Sleep long enough for the longest frontend dismiss path: the processing
@@ -394,7 +415,13 @@ pub fn hide_recording_overlay(app_handle: &AppHandle) {
         let window_clone = overlay_window.clone();
         std::thread::spawn(move || {
             std::thread::sleep(std::time::Duration::from_millis(1100));
-            let _ = window_clone.hide();
+            // Skip the native hide if another dictation started in the meantime —
+            // otherwise this stale timer hides the panel mid-recording, the bug
+            // behind issue #31 (recording pill flashes <1s / never appears).
+            let current_generation = OVERLAY_GENERATION.load(std::sync::atomic::Ordering::SeqCst);
+            if delayed_hide_is_current(scheduled_generation, current_generation) {
+                let _ = window_clone.hide();
+            }
         });
     }
 }
@@ -406,5 +433,25 @@ pub fn emit_levels(app_handle: &AppHandle, levels: &Vec<f32>) {
     // also emit to the recording overlay if it's open
     if let Some(overlay_window) = app_handle.get_webview_window("recording_overlay") {
         let _ = overlay_window.emit("mic-level", levels);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Regression test for issue #31: the recording overlay pill intermittently
+    // failed to appear (or flashed <1s) on macOS because a delayed hide() from
+    // the previous dictation fired into the next recording. The fix guards the
+    // delayed hide on the overlay generation.
+    #[test]
+    fn delayed_hide_runs_only_when_no_newer_show_occurred() {
+        // No show happened after the hide was scheduled → it should fire.
+        assert!(delayed_hide_is_current(7, 7));
+
+        // A newer show bumped the generation while the hide was pending → the
+        // stale hide must be skipped (this is the bug being fixed).
+        assert!(!delayed_hide_is_current(7, 8));
+        assert!(!delayed_hide_is_current(0, 1));
     }
 }


### PR DESCRIPTION
Closes #31.

## Symptom
On macOS, starting a recording via the global shortcut intermittently failed to show the **recording overlay pill** (~2/3 of the time for back-to-back dictations): the pill either never visibly appeared, or flashed for <1s then vanished. The rest of the flow (transcribing pill, paste) always worked.

## Root cause
`hide_recording_overlay` schedules a native `window.hide()` at **+1100ms unconditionally**. When a new dictation starts before that delay elapses, the **previous cycle's stale timer** fires and hides the NSPanel mid-way through the **new** recording. So the recording pill shows, animates correctly, then gets hidden ~450ms later → "flash <1s / never appears".

Only the *recording* state was affected because it is the only cold show from a hidden panel; `transcribing`/`processing` reuse the already-visible window, which is why they never glitched.

## How it was diagnosed
Followed a disciplined diagnosis loop (`/diagnose`):

1. **Built a feedback loop** with a programmatic signal — temporary `[DEBUG-ovl]` instrumentation on both sides (backend `show()/emit()/hide()` + a generation counter; frontend event-receipt, `performance.now()`, `document.visibilityState`, and the first rAF frame deltas), all funneled into `dictus.log` for one timestamped timeline. Driven via a script using the `--toggle-transcription` CLI flag over ~30 cycles with alternating 0.5s/2.0s gaps to probe the race.
2. **Ranked hypotheses**, then tested:
   - **H1 — WebKit occlusion/throttling of the hidden webview → REFUTED.** rAF ran at ~16ms from frame 1; the webview woke instantly.
   - **H2 — stale delayed `hide()` from the previous cycle → CONFIRMED.** Every `stale=true` hide lined up exactly with a `visibilitychange -> hidden` during the recording rAF frames.
3. **Fixed and re-ran the same loop to verify** — all cross-cycle hides are now skipped (`SKIPPED (newer show active)`), and no `hidden` event fires during recording.

## The fix
- Add a monotonic `OVERLAY_GENERATION` counter, bumped on every overlay show.
- The delayed `hide()` captures the generation at schedule time and only executes if no newer show has occurred since (otherwise the new dictation has taken over the panel and the stale hide must be skipped).
- The decision rule is extracted as the pure function `delayed_hide_is_current(scheduled, current)` with a **regression unit test** (`cargo test --lib overlay::` passes).

Net change: a single file (`src-tauri/src/overlay.rs`, +48/-1). All diagnostic instrumentation, the temporary debug command, frontend probes, and the driver script were removed (`grep DEBUG-ovl` is clean; `bindings.ts` unchanged).

## Validation
- `cargo fmt`, `cargo clippy --lib` (clean), `cargo test --lib overlay::` (passes).
- Feedback-loop re-run on macOS (M4 Pro) confirms the pill stays visible for the whole recording across rapid back-to-back cycles.

## Follow-up note (not in this PR)
The dismiss path still relies on a `sleep(1100ms)` timer, which is inherently racy. The generation guard fixes the bug minimally and correctly; a fully event-driven dismiss (explicit timer cancellation, or hide driven by the frontend fade-out completing) would remove the race window entirely — worth considering if the dismiss logic evolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)