### PR TITLE
chore(release): bump version to 0.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "handy-app",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1390,7 +1390,7 @@ dependencies = [
 
 [[package]]
 name = "dictus"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dictus"
-version = "0.2.0"
+version = "0.2.1"
 description = "Dictus Desktop — open-source speech-to-text for your desktop"
 authors = ["Dictus", "cjpais"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Dictus",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "identifier": "com.dictus.desktop",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
Version bump **0.2.0 → 0.2.1** ahead of the release.

Patch release (semver 0.x.y) — two user-facing bug fixes merged since 0.2.0, no new features, no breaking changes:

- **#34** (closes **#31**) — recording overlay pill intermittently failed to appear / flashed <1s on macOS. Fixed a stale delayed `hide()` from the previous dictation hiding the panel mid-recording (generation guard + regression test).
- **#32** — provider-agnostic translation flow, light-theme contrast fix, post-processing feedback.

Files bumped: `src-tauri/tauri.conf.json`, `package.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`.

Once merged, the `Release` workflow is dispatched on `main` → creates draft release `v0.2.1`, builds + signs all platforms, attaches assets. Final publish is manual after review.

> Note: #27 (recorder deadlock on Bluetooth audio stall + cancel pill during transcription/post-process) is **not** part of this release — it is still open and scoped separately as it touches the core audio concurrency path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)